### PR TITLE
Timeout error propogation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # resolute
-A resolute retry module for javascript 
+A resolute retry module for javascript
+
+``` javascript
+const test = async (message) => {
+    await some_promise(message);
+};
+
+const retry_test = resolute.retry(test, { max_retries: 3 });
+
+await retry_test('hello');
+```

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ module.exports = {
             try {
                 return await fn(...args);
             } catch(err) {
-                if(options.max_retries === undefined || options._attempts < options.max_retries) {
+                if(options.max_retries === undefined || options._attempts <= options.max_retries) {
                     let backoff;
 
                     if(options.backoff_policy === 'exponential') {

--- a/index.js
+++ b/index.js
@@ -15,6 +15,14 @@ module.exports = {
             options.backoff_duration = 1500;
         }
 
+        const _timeout = (backoff) => {
+            return new Promise((resolve) => {
+                return setTimeout(() => {
+                    return resolve();
+                }, backoff);
+            });
+        }
+
         const _retry = async (...args) => {
             try {
                 return await fn(...args);
@@ -32,9 +40,9 @@ module.exports = {
 
                     options._attempts++;
 
-                    return setTimeout(async () => {
-                        return await _retry(...args);
-                    }, backoff);
+                    await _timeout(backoff);
+
+                    return await _retry(...args);
                 } else {
                     throw err;
                 }


### PR DESCRIPTION
Previously when the retry logic was hit the timer was being returned instead of the eventual return  value or error. This wraps the timeout in promise and awaits it above the retry to fix error/return value propagation.